### PR TITLE
Fixing URL & Directory path in ReadMe

### DIFF
--- a/template/README.md
+++ b/template/README.md
@@ -31,8 +31,8 @@ you can run this template in a snatch.
     From a bash shell:
 
     ```shell
-    git clone https://github.com/botkit-ciscospark-samples
-    cd template
+    git clone https://github.com/CiscoDevNet/botkit-ciscospark-samples
+    cd botkit-ciscospark-samples/template
     npm install
     SPARK_TOKEN=0123456789abcdef PUBLIC_URL=https://abcdef.ngrok.io node bot.js
     ```

--- a/template/README.md
+++ b/template/README.md
@@ -34,7 +34,9 @@ you can run this template in a snatch.
     git clone https://github.com/CiscoDevNet/botkit-ciscospark-samples
     cd botkit-ciscospark-samples/template
     npm install
-    SPARK_TOKEN=0123456789abcdef PUBLIC_URL=https://abcdef.ngrok.io node bot.js
+    SPARK_TOKEN=0123456789abcdef
+    PUBLIC_URL=https://abcdef.ngrok.io
+    node bot.js
     ```
 
     From a windows shell:


### PR DESCRIPTION
The readme had wrong Git Repo URL and directory path. Fixing the same.